### PR TITLE
Add api arg for cli, for use on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [JQL](https://github.com/raybritton/json-query/blob/master/JQL.md) or these 
 * -q query
 * -i input file, json or url
 
-`java -jar jq-0.12.3.jar -i "example.json" -q "LIST \"id\" from \".people\""`
+`java -jar jq-0.13.1.jar -i "example.json" -q "LIST \"id\" from \".people\""`
 
 ## Usage
 
@@ -29,7 +29,7 @@ To use JQL go to https://jql-website.pending
 This isn't designed to be used as a library for programs but it can be added as a gradle dependency with:
 
 ```groovy
-compile 'com.raybritton.jsonquery:lib:0.12.3'
+compile 'com.raybritton.jsonquery:lib:0.13.1'
 ```
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 allprojects {
-    ext.jqVer = '0.13.0'
+    ext.jqVer = '0.13.1'
 
     repositories {
         jcenter()

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     compile project(':lib')
     testCompile 'junit:junit:4.12'
 }
@@ -12,10 +13,10 @@ dependencies {
 task fatJar(type: Jar) {
     manifest {
         attributes 'Implementation-Title': 'JsonQuery CLI',
-                'Implementation-Version': '0.13.0',
+                'Implementation-Version': '0.13.1',
                 'Main-Class': 'com.raybritton.jsonquery.MainKt'
     }
-    baseName = "jq-0.13.0"
+    baseName = "jq-0.13.1"
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }

--- a/cli/src/main/kotlin/com/raybritton/jsonquery/Main.kt
+++ b/cli/src/main/kotlin/com/raybritton/jsonquery/Main.kt
@@ -1,5 +1,7 @@
 package com.raybritton.jsonquery
 
+import com.google.gson.Gson
+
 /**
  * -q string : query
  * -i string : input file or json
@@ -11,20 +13,46 @@ fun main(args: Array<String>) {
     val jsonLoader = JsonLoader()
     val json = jsonLoader.load(progArgs.input)
     val jsonQuery = JsonQuery(json)
-    try {
-        val output = jsonQuery.query(progArgs.query)
-        println(output)
+
+    val result = run(jsonQuery, progArgs)
+
+    if (progArgs.forApi) {
+        val gson = Gson()
+        val output = mutableMapOf<Any, Any>()
+        if (result.first != null) {
+            output["result"] = result.first!!
+        } else {
+            output["error"] = mutableMapOf("message" to (result.second ?: "Unknown error"))
+            if (result.third != null) {
+                (output["error"] as MutableMap<String, String>)["extra"] = result.third!!
+            }
+        }
+        println(gson.toJson(output))
+    } else {
+        if (result.first != null) {
+            println(result.first)
+        } else {
+            println(result.second)
+            if (result.third != null) {
+                println(result.third)
+            }
+        }
+    }
+}
+
+private fun run(json: JsonQuery, args: ProgArgs): Triple<String?, String?, String?> {
+    return try {
+        val output = json.query(args.query)
+        Triple(output, null, null)
     } catch (e: SyntaxException) {
-        println("Unable to parse query: " + e.message)
-        if (progArgs.debug) {
+        if (args.debug) {
             e.printStackTrace()
         }
-        println(e.extraInfo?.text)
+        Triple(null, "Unable to parse query: " + e.message, e.extraInfo?.text)
     } catch (e: RuntimeException) {
-        println("Unable to run query: " + e.message)
-        if (progArgs.debug) {
+        if (args.debug) {
             e.printStackTrace()
         }
-        println(e.extraInfo?.text)
+        Triple(null, "Unable to run query: " + e.message, e.extraInfo?.text)
     }
 }

--- a/cli/src/main/kotlin/com/raybritton/jsonquery/ProgArgs.kt
+++ b/cli/src/main/kotlin/com/raybritton/jsonquery/ProgArgs.kt
@@ -3,7 +3,8 @@ package com.raybritton.jsonquery
 data class ProgArgs(val input: String,
                     val output: String?,
                     val query: String,
-                    val debug: Boolean) {
+                    val debug: Boolean,
+                    val forApi: Boolean) {
 
     companion object {
         fun build(args: Array<String>): ProgArgs {
@@ -11,9 +12,10 @@ data class ProgArgs(val input: String,
             var input: String? = null
             var output: String? = null
             var debug = false
+            var forApi = false
 
             var i = 0
-            while (i < args.size - 1) {
+            while (i < args.size) {
                 when (args[i]) {
                     "-q" -> {
                         query = args[i + 1]
@@ -30,6 +32,9 @@ data class ProgArgs(val input: String,
                     "-d" -> {
                         debug = true
                     }
+                    "-api" -> {
+                        forApi = true
+                    }
                 }
                 i++
             }
@@ -42,7 +47,7 @@ data class ProgArgs(val input: String,
                 throw IllegalStateException("A input file must be provided")
             }
 
-            return ProgArgs(input, output, query, debug)
+            return ProgArgs(input, output, query, debug, forApi)
         }
     }
 }


### PR DESCRIPTION
Using the cli with "-api" prints the result in json, e.g.

`{ "result": "{\"example\":\"json\"}"`

and with errors:

`{"error":{"message":"A quick explanation","extra":"Optional extra information about the issue"}}`